### PR TITLE
fix: Wrong error message when inviting (#15332)

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2468,5 +2468,8 @@
   "x_unmarked_as_no_show": "{{x}} unmarked as no-show",
   "no_show_updated": "No-show status updated for attendees",
   "email_copied": "Email copied",
+  "USER_PENDING_MEMBER_OF_THE_ORG": "User is a pending member of the organization",
+  "USER_ALREADY_INVITED_OR_MEMBER": "User is already invited or a member",
+  "USER_MEMBER_OF_OTHER_ORGANIZATION": "User is member of an organization that this team is not a part of.",
   "ADD_NEW_STRINGS_ABOVE_THIS_LINE_TO_PREVENT_MERGE_CONFLICTS": "↑↑↑↑↑↑↑↑↑↑↑↑↑ Add your new strings above here ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑"
 }

--- a/packages/features/ee/organizations/pages/settings/other-team-members-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/other-team-members-view.tsx
@@ -215,7 +215,7 @@ const MembersView = () => {
                       if (Array.isArray(data.usernameOrEmail)) {
                         showToast(
                           t("email_invite_team_bulk", {
-                            userCount: data.usernameOrEmail.length,
+                            userCount: data.numUsersInvited,
                           }),
                           "success"
                         );

--- a/packages/features/ee/teams/components/AddNewTeamMembers.tsx
+++ b/packages/features/ee/teams/components/AddNewTeamMembers.tsx
@@ -153,7 +153,7 @@ export const AddNewTeamMembersForm = ({
                     if (Array.isArray(data.usernameOrEmail)) {
                       showToast(
                         t("email_invite_team_bulk", {
-                          userCount: data.usernameOrEmail.length,
+                          userCount: data.numUsersInvited,
                         }),
                         "success"
                       );

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -134,7 +134,7 @@ export default function TeamListItem(props: Props) {
                 if (Array.isArray(data.usernameOrEmail)) {
                   showToast(
                     t("email_invite_team_bulk", {
-                      userCount: data.usernameOrEmail.length,
+                      userCount: data.numUsersInvited,
                     }),
                     "success"
                   );

--- a/packages/features/ee/teams/pages/team-members-view.tsx
+++ b/packages/features/ee/teams/pages/team-members-view.tsx
@@ -225,7 +225,7 @@ const MembersView = () => {
                       if (Array.isArray(data.usernameOrEmail)) {
                         showToast(
                           t("email_invite_team_bulk", {
-                            userCount: data.usernameOrEmail.length,
+                            userCount: data.numUsersInvited,
                           }),
                           "success"
                         );

--- a/packages/features/users/components/UserTable/InviteMemberModal.tsx
+++ b/packages/features/users/components/UserTable/InviteMemberModal.tsx
@@ -27,7 +27,7 @@ export function InviteMemberModal(props: Props) {
       if (Array.isArray(data.usernameOrEmail)) {
         showToast(
           t("email_invite_team_bulk", {
-            userCount: data.usernameOrEmail.length,
+            userCount: data.numUsersInvited,
           }),
           "success"
         );


### PR DESCRIPTION
* fix: Wrong message when inviting

* Fix num users invited

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


---

<!-- kody-pr-summary:start -->
This pull request significantly improves the user invitation process by providing more precise feedback and accurate success messages.

Key changes include:

*   **Enhanced Error Handling for Single Invites**: When inviting a single user, the system now displays specific error messages that clearly explain why an invitation might fail. This includes scenarios where the user is already a member, has a pending organization invitation, or is a member of another organization that the team is not a part of.
*   **Accurate Bulk Invite Success Count**: The success toast message for bulk invitations now correctly reflects the number of users who were successfully invited, rather than just the total number of emails provided in the input.
*   **Refactoring of Invitation Utilities**: Several internal utility functions related to invitation logic have been renamed for improved clarity and consistency, such as `getUsernameOrEmailsToInvite` to `getUniqueUsernameOrEmailsOrThrow` and `getIsOrgVerified` to `getOrgState`.
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where the error messages displayed during team member invitations were not specific enough, and the success message incorrectly reported the number of attempted invites instead of the number of successful invites.

The changes include:

*   **Improved Success Messages:** Frontend toast notifications now display the precise number of users successfully invited, rather than the total count of usernames or emails initially provided. This is achieved by updating the `inviteMember` API to return `numUsersInvited` and consuming this new field in the UI components.
*   **Detailed Error Messages for Single Invites:** When inviting a single user, the system now provides specific error messages if the user cannot be invited due to reasons such as already being a member, having a pending invitation to the organization, or being a member of a different organization. This replaces a generic error message.
*   **Refactored Invitation Logic:** The backend logic for determining user invitation eligibility has been enhanced to use a new `INVITE_STATUS` enum, allowing for more granular and descriptive states (e.g., `USER_ALREADY_INVITED_OR_MEMBER`, `USER_PENDING_MEMBER_OF_THE_ORG`, `USER_MEMBER_OF_OTHER_ORGANIZATION`, `CAN_BE_INVITED`). This provides the foundation for the improved error reporting.
*   **Utility Function Renames:** Several internal utility functions related to invitation processing have been renamed for clarity (e.g., `getUsernameOrEmailsToInvite` to `getUniqueUsernameOrEmailsOrThrow`, `getIsOrgVerified` to `getOrgState`).
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where incorrect or generic error messages were displayed during user invitations and improves the accuracy of success messages for bulk invites.

Key changes include:

*   **Enhanced Error Messaging for Single User Invites:** The backend now provides specific error messages when a single user cannot be invited, detailing the reason (e.g., user is already a member, pending organization membership, or belongs to another organization). This replaces a generic error message.
*   **Accurate Bulk Invite Success Count:** The backend now calculates and returns the exact number of users successfully invited (`numUsersInvited`). All relevant frontend components have been updated to display this accurate count in success toast messages for bulk invitations, rather than just the number of provided email/username inputs.
*   **Refactored Invitation Logic:** The `canBeInvited` utility function has been updated to return a detailed `INVITE_STATUS` enum, allowing for more granular handling of different invitation scenarios.
*   **Improved Code Clarity:** Several utility functions in the invitation process have been renamed for better readability and understanding (e.g., `getUsernameOrEmailsToInvite` to `getUniqueUsernameOrEmailsOrThrow`, `getIsOrgVerified` to `getOrgState`).
<!-- kody-pr-summary:end -->